### PR TITLE
Fixed image name typo

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -1,5 +1,5 @@
 name: hello-world
-image: okteto/hello-world:php-dev
+image: okteto.dev/hello-world:php-dev
 workdir: /app
 command: [ "php", "-S", "0.0.0.0:8080"]
 forward: 


### PR DESCRIPTION
The image path in the `okteto.yml` file is invalid and, as a result, resolves to an error when users follow the guide on https://okteto.com/docs/samples/php.