### PR TITLE
upgrade xdebug configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7 as base
+FROM php:8 as base
 WORKDIR /app
 COPY . /app
 
@@ -6,11 +6,11 @@ COPY . /app
 
 FROM base AS dev
 
-RUN apt-get update && apt-get install -y zip git libzip-dev && \ 
+RUN apt-get update && apt-get install -y zip git libzip-dev && \
   pecl install xdebug && echo 'zend_extension="xdebug.so"' > /usr/local/etc/php/conf.d/xdebug.ini && \
   pecl install zip && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/zip.ini && \
   php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-  php composer-setup.php --install-dir /usr/local/bin && \ 
+  php composer-setup.php --install-dir /usr/local/bin && \
   ln -s /usr/local/bin/composer.phar /usr/local/bin/composer && \
   unlink composer-setup.php && \
   /usr/local/bin/composer global require laravel/installer

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,7 +1,6 @@
 zend_extension="xdebug.so"
-xdebug.remote_enable=1
-xdebug.remote_host=127.0.0.1
-xdebug.remote_port=9000
-xdebug.remote_autostart=1
+xdebug.mode=debug
+xdebug.start_with_request=yes
+xdebug.client_host=127.0.0.1
+xdebug.client_port=9000
 xdebug.remote_handler = dbgp
-xdebug.remote_mode = req


### PR DESCRIPTION
# Proposed changes

Add the new xdebug configuration following [xdebug upgrade guide](https://xdebug.org/docs/upgrade_guide):

- `xdebug.remote_enable` has been replaced with `xdebug.mode=debug`
- `xdebug.remote_host` has been replaced with `xdebug.client_host`
- `xdebug.remote_port` has been replaced with `xdebug.client_port`
- `xdebug.remote_autostart` has been replaced with `xdebug.start_with_request`
- `xdebug.remote_mode` has been removed since we already were using `xdebug.start_with_request=yes`
- `xdebug.remote_handler` don't have any modification